### PR TITLE
[#66667110] Adds command to list instances attached to a load balancer

### DIFF
--- a/lib/elba/cli.rb
+++ b/lib/elba/cli.rb
@@ -71,6 +71,34 @@ module Elba
     end
 
 
+    desc "attached BALANCER", "Prints the list of instances attached to a balancer"
+    option :porcelain, type: :boolean, aliases: :p, desc: "Prints the list in a machine readable format"
+    def attached(balancer_name = nil, porcelain = options[:porcelain])
+      unless balancer_name
+        error "You must specify an ELB"
+        return
+      end
+
+      elb = find_elb(name: balancer_name)
+
+      unless elb
+        error "Could not find balancer"
+        return
+      end
+
+      instances = elb.reload.instances
+
+      if porcelain
+        say instances.join(' ')
+      else
+        say " * #{elb.id}"
+        instances.each do |instance_id|
+          success "   - #{instance_id}"
+        end
+      end
+    end
+
+
     desc "attach INSTANCES", "Attaches given instances ids to a load balancer"
     option :to, type: :string, aliases: :t, desc: "Specifies which load balancer to use"
     def attach(*instances)

--- a/spec/lib/elba/cli_spec.rb
+++ b/spec/lib/elba/cli_spec.rb
@@ -62,6 +62,48 @@ describe Elba::Cli do
     end
   end
 
+  describe 'attached' do
+    let(:output)  { capture(:stdout) { perform } }
+    let(:perform) { subject.attached elb.id }
+
+    before do
+      silence(:stdout) { subject.client.attach(instance1.id, elb) }
+      silence(:stdout) { subject.client.attach(instance2.id, elb) }
+    end
+
+    it 'prints the list of instances attached to an ELB' do
+      output.should include " * #{elb.id}"
+      output.should include "  - #{instance1.id}"
+      output.should include "  - #{instance2.id}"
+    end
+
+    context 'no balancer name is passed' do
+      let(:perform) { subject.attached }
+
+      it 'exits' do
+        output.should include 'You must specify an ELB'
+      end
+    end
+
+    context "the balancer can't be found" do
+      let(:perform) { subject.attached 'yolo' }
+
+      it 'exits' do
+        output.should include 'Could not find balancer'
+      end
+    end
+
+    context '--porcelain' do
+      before do
+        subject.stub options: { porcelain: true }
+      end
+
+      it 'prints the list of instances attached to an ELB without decoration' do
+        output.should include "#{instance1.id} #{instance2.id}"
+      end
+    end
+  end
+
   describe 'attach' do
     shared_examples_for "asking user" do
       before do


### PR DESCRIPTION
For the maintenance app we need a command to list all the machines attached to a certain load balancer.

```
$ elba help attached
Usage:
  elba attached BALANCER

Options:
  p, [--porcelain]  # Prints the list in a machine readable format

Prints the list of instances attached to a balancer
```

```
$ elba attached testing-loadbalancer
 * testing-loadbalancer
   - i-886613c1
   - i-fe6613b7
```
