### PR TITLE
Specify fog aws dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
-source 'http://housetripgems.herokuapp.com'
+source 'https://rubygems.org'
 
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,31 +1,38 @@
 PATH
   remote: .
   specs:
-    elba (0.0.4)
-      fog
-      thor
+    elba (0.0.5)
+      fog-aws
+      thor (>= 0.15)
 
 GEM
-  remote: http://housetripgems.herokuapp.com/
+  remote: https://rubygems.org/
   specs:
     builder (3.2.2)
     celluloid (0.15.2)
       timers (~> 1.1.0)
     coderay (1.0.9)
     diff-lcs (1.2.4)
-    excon (0.27.6)
+    excon (0.45.4)
     ffi (1.9.0)
-    fog (1.16.0)
+    fog-aws (0.7.6)
+      fog-core (~> 1.27)
+      fog-json (~> 1.0)
+      fog-xml (~> 0.1)
+      ipaddress (~> 0.8)
+    fog-core (1.32.1)
       builder
-      excon (~> 0.27.0)
-      formatador (~> 0.2.0)
+      excon (~> 0.45)
+      formatador (~> 0.2)
       mime-types
-      multi_json (~> 1.0)
       net-scp (~> 1.1)
       net-ssh (>= 2.1.3)
-      nokogiri (~> 1.5)
-      ruby-hmac
-      unicode (~> 0.4.4)
+    fog-json (1.0.2)
+      fog-core (~> 1.0)
+      multi_json (~> 1.10)
+    fog-xml (0.1.2)
+      fog-core
+      nokogiri (~> 1.5, >= 1.5.11)
     formatador (0.2.4)
     guard (2.2.2)
       formatador (>= 0.2.4)
@@ -36,20 +43,21 @@ GEM
     guard-rspec (3.0.2)
       guard (>= 1.8)
       rspec (~> 2.13)
+    ipaddress (0.8.0)
     listen (2.1.1)
       celluloid (>= 0.15.2)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
     lumberjack (1.0.4)
     method_source (0.8.2)
-    mime-types (1.25)
-    mini_portile (0.5.1)
-    multi_json (1.8.2)
-    net-scp (1.1.2)
+    mime-types (2.6.1)
+    mini_portile (0.6.2)
+    multi_json (1.11.2)
+    net-scp (1.2.1)
       net-ssh (>= 2.6.5)
-    net-ssh (2.7.0)
-    nokogiri (1.6.0)
-      mini_portile (~> 0.5.0)
+    net-ssh (2.9.2)
+    nokogiri (1.6.6.2)
+      mini_portile (~> 0.6.0)
     pry (0.9.12.2)
       coderay (~> 1.0.5)
       method_source (~> 0.8)
@@ -68,11 +76,9 @@ GEM
     rspec-expectations (2.14.3)
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.14.4)
-    ruby-hmac (0.4.0)
     slop (3.4.6)
     thor (0.18.1)
     timers (1.1.0)
-    unicode (0.4.4)
 
 PLATFORMS
   ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    elba (0.0.5)
+    elba (0.0.6)
       fog-aws
       thor (>= 0.15)
 

--- a/elba.gemspec
+++ b/elba.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "pry"
   s.add_development_dependency "pry-nav"
 
-  s.add_dependency "fog"
+  s.add_dependency "fog-aws"
   s.add_dependency "thor", '>= 0.15'
 
   s.files        = `git ls-files`.split("\n")

--- a/lib/elba.rb
+++ b/lib/elba.rb
@@ -1,5 +1,5 @@
 # encoding: UTF-8
 
 module Elba
-  VERSION = "0.0.5"
+  VERSION = "0.0.6"
 end

--- a/lib/elba/client.rb
+++ b/lib/elba/client.rb
@@ -1,6 +1,6 @@
 # encoding: UTF-8
 
-require 'fog'
+require 'fog/aws'
 require 'forwardable'
 
 module Elba


### PR DESCRIPTION
Loading the whole `fog` gem is extremely slow. Since we are using only the AWS, we only need this provider.